### PR TITLE
~FairContFact must remove itself from contFactories list to avoid double deletion

### DIFF
--- a/parbase/FairContFact.cxx
+++ b/parbase/FairContFact.cxx
@@ -152,6 +152,7 @@ FairContFact::FairContFact()
 FairContFact::~FairContFact()
 {
   // Destructor deletes the container list and its elements
+  FairRuntimeDb::instance()->removeContFactory(this);
   containers->Delete();
   delete containers;
 }

--- a/parbase/FairRuntimeDb.cxx
+++ b/parbase/FairRuntimeDb.cxx
@@ -111,6 +111,14 @@ void FairRuntimeDb::addContFactory(FairContFact* fact)
   }
 }
 
+void FairRuntimeDb::removeContFactory(FairContFact* fact)
+{
+  // removes a container factory to the list of factories
+  if ((contFactories.Remove(fact))) {
+    fLogger->Debug( MESSAGE_ORIGIN,"removed RTDB container factory %s",fact->GetName() );
+  }
+}
+
 FairContFact* FairRuntimeDb::getContFactory(const Text_t* FactName)
 {
   return (static_cast<FairContFact*>(contFactories.FindObject(FactName)));

--- a/parbase/FairRuntimeDb.h
+++ b/parbase/FairRuntimeDb.h
@@ -59,6 +59,7 @@ class FairRuntimeDb : public TObject
     Bool_t addParamContext(const char*);
     void printParamContexts();
     void addContFactory(FairContFact*);
+    void removeContFactory(FairContFact* fact);
     FairContFact* getContFactory(const Text_t*);
 
     Bool_t addContainer(FairParSet*);


### PR DESCRIPTION
Hi @MohammadAlTurany

With new ROOT/v6-12-04 we get double delete on root exit cleanup due to the FairRoot static  FairContFact mechanism:

``root -l -x -b -q /home/shahoian/alice/sw/BUILD/FairRoot-latest/FairRoot/lib/libTrkBase.so
Processing /home/shahoian/alice/sw/BUILD/FairRoot-latest/FairRoot/lib/libTrkBase.so...
Error in <TList::Clear>: A list is accessing an object (0x7f17821558a0) already deleted (list name = TList)
``
The reason is that different static FairContFact-derived objects (e.g. ````FairRoot/base/sim/FairBaseContFact.cxx:static FairBaseContFact gFairBaseContFact````) register themselves in the ````static TList contFactories```` defined in ````FairRuntimeDb.h```` via their base FairContFact constructor. On exit from root these static FairContFact objects are deleted once as TObjects known to root then accessed/deleted when the ````static contFactories```` is garbage-collected. 
Below I'll paste the dump from gdb showing which deleted instances are accessed from the list.

This patch forces the FairBaseContFact::~FairBaseContFact to remove the object from the contFactories.

Cheers,
 Ruben

===========================
````
root [0] .x run_digi.C(50e3)
...

(gdb) bre TList.cxx:441
Breakpoint 1 at 0x7ffff77e40b4: file /home/shahoian/alice/sw/SOURCES/ROOT/v6-12-04/v6-12-04/core/cont/src/TList.cxx, line 441.
(gdb) cont
Continuing.
root [1] .q
[DEBUG  ] Enter Destructor of FairRootManager
[DEBUG  ] Leave Destructor of FairRootManager
[DEBUG  ] FairRootManager::~FairRootManager: going to lock 0 0xa16bd8
[DEBUG  ] Released lock and done FairRootManager::~FairRootManager in 0 0xa16bd8

Breakpoint 1, TList::Clear (this=0x7fffe9883e20 <_ZL13contFactories>, option=<optimized out>) at /home/shahoian/alice/sw/SOURCES/ROOT/v6-12-04/v6-12-04/core/cont/src/TList.cxx:441
441                Error("Clear", "A list is accessing an object (%p) already deleted (list name = %s)",...
Error in <TList::Clear>: A list is accessing an object (0x7fffe9c0c8a0) already deleted (list name = TList)
(gdb) print ((TObject*)0x7fffe9c0c8a0)
$1 = (TObject *) 0x7fffe9c0c8a0 <gFairBaseContFact>
(gdb) cont
Continuing.

Breakpoint 1, TList::Clear (this=0x7fffe9883e20 <_ZL13contFactories>, option=<optimized out>) at /home/shahoian/alice/sw/SOURCES/ROOT/v6-12-04/v6-12-04/core/cont/src/TList.cxx:441
441                Error("Clear", "A list is accessing an object (%p) already deleted (list name = %s)",...
Error in <TList::Clear>: A list is accessing an object (0x7fffe5416960) already deleted (list name = TList)
427          auto tlk = fFirst;
(gdb) print ((TObject*)0x7fffe5416960)
$2 = (TObject *) 0x7fffe5416960 <gMagFieldContFact>
(gdb) cont
Continuing.

Breakpoint 1, TList::Clear (this=0x7fffe9883e20 <_ZL13contFactories>, option=<optimized out>) at /home/shahoian/alice/sw/SOURCES/ROOT/v6-12-04/v6-12-04/core/cont/src/TList.cxx:441
441                Error("Clear", "A list is accessing an object (%p) already deleted (list name = %s)",..
Error in <TList::Clear>: A list is accessing an object (0x7fffe21a8940) already deleted (list name = TList)
(gdb) print ((TObject*)0x7fffe21a8940)
$3 = (TObject *) 0x7fffe21a8940 <gO2itsContFact>
(gdb) cont
Continuing.

Breakpoint 1, TList::Clear (this=0x7fffe9883e20 <_ZL13contFactories>, option=<optimized out>) at /home/shahoian/alice/sw/SOURCES/ROOT/v6-12-04/v6-12-04/core/cont/src/TList.cxx:441
441                Error("Clear", "A list is accessing an object (%p) already deleted (list name = %s)",...
Error in <TList::Clear>: A list is accessing an object (0x7fffe11e3b80) already deleted (list name = TList)
427          auto tlk = fFirst;
(gdb) print ((TObject*)0x7fffe11e3b80)
$4 = (TObject *) 0x7fffe11e3b80 <gPassiveContFact>
(gdb) cont
Continuing.
[Inferior 1 (process 27568) exited normally]
````
